### PR TITLE
fix #1: added keystore.password parameter to install.sh call

### DIFF
--- a/install
+++ b/install
@@ -59,6 +59,7 @@ $DIST/bin/install.sh \
     -Didp.scope=$SCOPE \
     -Didp.host.name=$HOST \
     -Didp.sealer.password=$SEALPASS \
+    -Dipd.keystore.password=$UFPASS \
     -Didp.noprompt=true \
     -Didp.jetty.config=true
 


### PR DESCRIPTION
With this change `./install` builds successfully.
