### PR TITLE
Moving Shibboleth IdP install process to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,33 +64,11 @@ into `fetched/shibboleth-dist`. A variable at the top of the script controls the
 Some minimal validation is performed of the downloaded file using a file of PGP keys published by
 the Shibboleth project and included here to avoid taking a complete "leap of faith" approach.
 
-## Installing Host Java
-
-The `install` script relies on executing the Shibboleth installation process *outside* the container.
-This is not ideal, and at some point I may move to performing this operation inside a second
-container spun up for the purpose. For the moment, though, this means that you need to install
-Java on your Docker host and note its home location. The OpenJDK variant of Java 7 is sufficient
-for this.
-
-On an Ubuntu 14.04 LTS system, the installation of Java on your host can be performed as follows:
-
-    # apt-get install openjdk-7-jre
-
-Your "Java home" can normally be found by looking in `/usr/lib/jvm`:
-
-    # ls /usr/lib/jvm
-    java-1.7.0-openjdk-amd64  java-7-openjdk-amd64
-
-In this case, you can use `/usr/lib/jvm/java-7-openjdk-amd64` as your "Java home".
-
 ## Shibboleth "Install"
 
-Before attempting the next step, you should edit the `install` script to change the critical
+Before attempting the next step, you should edit the `install-idp` script to change the critical
 parameters at the top:
 
-* `JAVA_HOME`: this should be set to your Docker host's Java home location as determined in
-the "Installing Java" section above.
-The provided value works on Ubuntu 14.04 LTS but your platform may well differ.
 * `UFPASS` and `SEALERPASS` are passwords to use if the user-facing TLS credential or data sealer keystores,
 respectively, need to be generated. It's arguable whether changing the default `X-changethis` values
 really adds any security given that the values are just put in the clear in property files anyway.
@@ -98,9 +76,9 @@ really adds any security given that the values are just put in the clear in prop
 * `HOST` is built from `SCOPE` by prepending `idp2.`, which probably won't suit you.
 * `ENTITYID` is built from `HOST`. The default here is the same as the interactive install would suggest.
 
-Executing the `./install` script will now run the Shibboleth install process. If you do not have a `shibboleth-idp`
-directory, this will act like a first-time install using the parameters you set before, resulting in a
-basic installation in that directory.
+Executing the `./install` script will now run the Shibboleth install process in a container based on the
+`iay/java:oracle-8` image. If you do not have a `shibboleth-idp` directory, this will act like a first-time
+install using the parameters you set before, resulting in a basic installation in that directory.
 
 If `shibboleth-idp` already exists, `./install` will act to upgrade it to the latest distribution. This should
 be idempotent; you should be able to just run `./install` at any time without changing the results. In this

--- a/install
+++ b/install
@@ -1,100 +1,12 @@
 #!/bin/bash
 
-# Where is Java on the *host* (as opposed to in the container)
-export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
-
-# Password for any auto-generated user-facing TLS credential
-UFPASS=userfacing-changethis
-
-# Password for any auto-generated cookie encryption keystore
-SEALPASS=sealer-changethis
-
-# Scope for the IdP
-SCOPE=iay.org.uk
-
-# Host name for the container
-HOST=idp2.$SCOPE
-
-# Entity ID for the identity provider
-ENTITYID=https://$HOST/idp/shibboleth
-
-
-
-DIST=`pwd`/fetched/shibboleth-dist
-IDP_HOME=`pwd`/shibboleth-idp
-
 #
-# Set up the property files for the Shibboleth install.
-# These files are deleted by the install process so
-# we rebuild them every time in the same way as the
-# Windows installer does.
+# Run the IdP installer in a container.
 #
 
-I=$DIST/idp.install.properties
-echo \# Properties controlling the installation of the Shibboleth IdP>$I
-# Uncomment the following to preserve the property files
-# echo idp.no.tidy=true>>$I
-
-S=$DIST/idp.merge.properties
-echo idp.scope=$SCOPE>>$S
-echo idp.entityID=$ENTITYID>>$S
-echo idp.sealer.storePassword=$SEALPASS>>$S
-echo idp.sealer.keyPassword=$SEALPASS>>$S
-
-#
-# Perform the Shibboleth IdP install process.
-#
-# idp.src.dir is the location of the Shibboleth IdP distribution
-# idp.target.dir is the location of the installation
-#
-# idp.jetty.config is set to provide us with an updated jetty-base
-# tree. The start.d from this tree will be in start.d.dist, while
-# the old start.d from a previous install will be retained.
-#
-$DIST/bin/install.sh \
-    -Didp.property.file=idp.install.properties \
-    -Didp.merge.properties=idp.merge.properties \
-    -Didp.src.dir=$DIST \
-    -Didp.target.dir=$IDP_HOME \
-    -Didp.scope=$SCOPE \
-    -Didp.host.name=$HOST \
-    -Didp.sealer.password=$SEALPASS \
-    -Didp.keystore.password=$UFPASS \
-    -Didp.noprompt=true \
-    -Didp.jetty.config=true
-
-#
-# Set up the property files for the Jetty install.
-# These files are deleted by the install process so
-# we rebuild them every time in the same way as the
-# Windows installer does.
-#
-
-J=$IDP_HOME/jetty.install.properties
-echo \# Properties controlling the installation of Jetty>$J
-echo jetty.merge.properties=jetty.merge.properties>>$J
-echo idp.host.name=$HOST>>$J
-echo idp.keystore.password=$UFPASS>>$J
-echo idp.uri.subject.alt.name=$ENTITYID>>$J
-echo idp.target.dir=$IDP_HOME>>$J
-# Uncomment the following to preserve the property files
-# echo jetty.no.tidy=true>>$J
-
-M=$IDP_HOME/jetty.merge.properties
-echo \# Properties to be merged into the idp.ini file>$M
-echo jetty.host=0.0.0.0>>$M
-echo jetty.https.port=443>>$M
-echo jetty.backchannel.port=8443>>$M
-echo jetty.backchannel.keystore.password=$UFPASS>>$M
-echo jetty.browser.keystore.password=$UFPASS>>$M
-echo jetty.nonhttps.port=localhost>>$M
-echo jetty.nonhttps.port=80>>$M
-
-#
-# Perform the install process for Jetty. This merges
-# properties into the idp.ini file in start.d
-# if it does not already exist.
-#
-$DIST/bin/ant.sh -f $IDP_HOME/bin/ant-jetty.xml \
-    -Djetty.property.file=jetty.install.properties
-
+docker run --rm \
+    -v `pwd`/shibboleth-idp:/opt/shibboleth-idp \
+    -v `pwd`/fetched/shibboleth-dist:/data/shibboleth-dist \
+    -v `pwd`/install-idp:/data/install-idp \
+    iay/java:oracle-8 \
+    /data/install-idp

--- a/install-idp
+++ b/install-idp
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Password for any auto-generated user-facing TLS credential
+UFPASS=userfacing-changethis
+
+# Password for any auto-generated cookie encryption keystore
+SEALPASS=sealer-changethis
+
+# Scope for the IdP
+SCOPE=iay.org.uk
+
+# Host name for the container
+HOST=idp2.$SCOPE
+
+# Entity ID for the identity provider
+ENTITYID=https://$HOST/idp/shibboleth
+
+
+
+DIST=/data/shibboleth-dist
+IDP_HOME=/opt/shibboleth-idp
+
+#
+# Set up the property files for the Shibboleth install.
+# These files are deleted by the install process so
+# we rebuild them every time in the same way as the
+# Windows installer does.
+#
+
+I=$DIST/idp.install.properties
+echo \# Properties controlling the installation of the Shibboleth IdP>$I
+# Uncomment the following to preserve the property files
+# echo idp.no.tidy=true>>$I
+
+S=$DIST/idp.merge.properties
+echo idp.scope=$SCOPE>>$S
+echo idp.entityID=$ENTITYID>>$S
+echo idp.sealer.storePassword=$SEALPASS>>$S
+echo idp.sealer.keyPassword=$SEALPASS>>$S
+
+#
+# Perform the Shibboleth IdP install process.
+#
+# idp.src.dir is the location of the Shibboleth IdP distribution
+# idp.target.dir is the location of the installation
+#
+# idp.jetty.config is set to provide us with an updated jetty-base
+# tree. The start.d from this tree will be in start.d.dist, while
+# the old start.d from a previous install will be retained.
+#
+$DIST/bin/install.sh \
+    -Didp.property.file=idp.install.properties \
+    -Didp.merge.properties=idp.merge.properties \
+    -Didp.src.dir=$DIST \
+    -Didp.target.dir=$IDP_HOME \
+    -Didp.scope=$SCOPE \
+    -Didp.host.name=$HOST \
+    -Didp.sealer.password=$SEALPASS \
+    -Didp.keystore.password=$UFPASS \
+    -Didp.noprompt=true \
+    -Didp.jetty.config=true
+
+#
+# Set up the property files for the Jetty install.
+# These files are deleted by the install process so
+# we rebuild them every time in the same way as the
+# Windows installer does.
+#
+
+J=$IDP_HOME/jetty.install.properties
+echo \# Properties controlling the installation of Jetty>$J
+echo jetty.merge.properties=jetty.merge.properties>>$J
+echo idp.host.name=$HOST>>$J
+echo idp.keystore.password=$UFPASS>>$J
+echo idp.uri.subject.alt.name=$ENTITYID>>$J
+echo idp.target.dir=$IDP_HOME>>$J
+# Uncomment the following to preserve the property files
+# echo jetty.no.tidy=true>>$J
+
+M=$IDP_HOME/jetty.merge.properties
+echo \# Properties to be merged into the idp.ini file>$M
+echo jetty.host=0.0.0.0>>$M
+echo jetty.https.port=443>>$M
+echo jetty.backchannel.port=8443>>$M
+echo jetty.backchannel.keystore.password=$UFPASS>>$M
+echo jetty.browser.keystore.password=$UFPASS>>$M
+echo jetty.nonhttps.port=localhost>>$M
+echo jetty.nonhttps.port=80>>$M
+
+#
+# Perform the install process for Jetty. This merges
+# properties into the idp.ini file in start.d
+# if it does not already exist.
+#
+$DIST/bin/ant.sh -f $IDP_HOME/bin/ant-jetty.xml \
+    -Djetty.property.file=jetty.install.properties
+


### PR DESCRIPTION
As you note in the readme, installing the IdP software outside a container, and requiring a JRE to do so, isn't ideal. This moves that process to happen inside a run of your `iay/java:oracle-8` image.